### PR TITLE
[fix] Reload supervisor service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: reload supervisor
-  command: supervisord
+  service:
+    name: supervisor
+    state: restarted
   become: true
 
 - name: restart nginx

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -35,7 +35,7 @@
       fail:
         msg: "The file is not uploaded."
       when: not translation_file.stat.exists
-    
+
     - name: Checking static file is copied
       stat:
         path: "/opt/openwisp2/wifi-login-pages/static/test_static_file"


### PR DESCRIPTION
Using "supervisord" will start another service which throws errors
on system already having a supervisor service running