### PR TITLE
[fix] Role should not fail if dir do not exists

### DIFF
--- a/tasks/yarn.yml
+++ b/tasks/yarn.yml
@@ -42,6 +42,7 @@
     owner: "{{ www_user }}"
     group: "{{ www_group }}"
     mode: 0640
+  failed_when: false
 
 - name: copy translations (i18n directory)
   become: true
@@ -51,6 +52,7 @@
     owner: "{{ www_user }}"
     group: "{{ www_group }}"
     mode: 0640
+  failed_when: false
 
 - name: copy static files
   become: true
@@ -60,6 +62,7 @@
     owner: "{{ www_user }}"
     group: "{{ www_group }}"
     mode: 0640
+  failed_when: false
 
 - name: yarn build
   become: true


### PR DESCRIPTION
Ignore errors if `owlp_i18n`, `owlp_organizations` or `owlp_static` do not exists.

Fixes #12