### PR TITLE
[fix] Override cache control to disable cache of nodeJS responses #14

### DIFF
--- a/templates/nginx.j2
+++ b/templates/nginx.j2
@@ -31,6 +31,11 @@ server {
                application/x-font-ttf font/opentype;
 
     location @nodejs {
+        proxy_hide_header Cache-Control;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+
         proxy_set_header   X-Forwarded-For $remote_addr;
         proxy_set_header   Host $http_host;
         proxy_pass         http://localhost:3030;


### PR DESCRIPTION
This patch allows to ensure HTML content (which is always pretty small)
is not cached, to avoid users continue loading older versions of the app.

Fixes #14