### PR TITLE
[change] Replace supervisor service restart with targeted process restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,11 +5,13 @@
     state: started
     enabled: yes
 
-- name: reload supervisor
-  shell: |
-    supervisorctl reread
-    supervisorctl update
-    supervisorctl restart wifi_login_pages || supervisorctl start wifi_login_pages
+- name: Update supervisor configuration
+  command: supervisorctl update wifi_login_pages
+  register: supervisord_update_wifi_login_pages
+
+- name: Restart wifi_login_pages
+  command: supervisorctl restart wifi_login_pages
+  when: not (supervisord_update_wifi_login_pages is defined and "wifi_login_pages:" in supervisord_update_wifi_login_pages.stdout)
 
 - name: restart nginx
   service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,17 +4,14 @@
     name: supervisor
     state: started
     enabled: yes
-  become: true
 
 - name: reload supervisor
   shell: |
     supervisorctl reread
     supervisorctl update
     supervisorctl restart wifi_login_pages || supervisorctl start wifi_login_pages
-  become: true
 
 - name: restart nginx
   service:
     name: nginx
     state: restarted
-  become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,20 @@
 ---
-
-- name: reload supervisor
+- name: Start and enable supervisor service
   service:
     name: supervisor
-    state: restarted
+    state: started
+    enabled: yes
+  become: true
+
+- name: reload supervisor
+  shell: |
+    supervisorctl reread
+    supervisorctl update
+    supervisorctl restart wifi_login_pages || supervisorctl start wifi_login_pages
   become: true
 
 - name: restart nginx
   service:
     name: nginx
     state: restarted
+  become: true

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -1,4 +1,10 @@
 ---
+- name: Start and enable supervisor service
+  service:
+    name: supervisor
+    state: started
+    enabled: yes
+  become: true
 
 - name: supervisor configuration
   template:

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -5,9 +5,10 @@
     state: started
     enabled: yes
   become: true
+  notify: Update supervisor configuration
 
 - name: supervisor configuration
   template:
     src: supervisor.j2
     dest: "{{ supervisor_path | format('wifi_login_pages') }}"
-  notify: reload supervisor
+  notify: Update supervisor configuration


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #38.

## Description of Changes

- Add task to ensure supervisor service is started before config changes
- Update reload supervisor handler to use supervisorctl for targeted restart
- Handler now reloads config (reread/update) then restarts specific process(wifi_login_pages).
- Add fallback to start process if restart fails
