### PR TITLE
[qa] Fixed lint errors which were ignored #42

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,12 +3,9 @@
 exclude_paths:
   - /files/
 skip_list:
-  - '204'   # Lines should be no longer than 160 chars
-  - '301'   # Commands should not change things if nothing needs doing
-  - '303'   # Using command rather than module
-  - '306'   # Shells that use pipes should set the pipefail option
-  - '403'   # Package installs should not use latest
-  - '106'   # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern'
+  - command-instead-of-module  # Using command rather than module
+  - package-latest  # Package installs should not use latest
+  - role-name  # Role name does not match pattern
   - git-latest
   - meta-no-info
   - experimental

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
+---
 # These are supported funding model platforms
 
 github: [openwisp]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "pip" # Check for Python package updates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 ---
-
 name: Ansible OpenWISP WiFi Login Pages CI Build
 
-on:             # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   push:
     branches:
       - master
@@ -33,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install Dependencies
         id: deps
@@ -43,8 +42,7 @@ jobs:
           ansible-galaxy collection install "community.general:>=3.6.0"
 
       - name: QA checks
-        run: |
-          openwisp-qa-check --skip-isort --skip-flake8 --skip-checkmigrations --skip-black
+        run: ./run-qa-checks
 
       - name: Tests
         if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
@@ -54,6 +52,6 @@ jobs:
           molecule test
         env:
           ROLE_NAME: openwisp2
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
           MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,3 +5,11 @@ rules:
   line-length:
     max: 160
     level: warning
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: reload supervisor
-  service:
+- name: Reload supervisor
+  ansible.builtin.service:
     name: supervisor
     state: restarted
   become: true
 
-- name: restart nginx
-  service:
+- name: Restart nginx
+  ansible.builtin.service:
     name: nginx
     state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,8 @@ galaxy_info:
   author: OpenWISP
   company: OpenWISP
   description: Role to install and upgrade OpenWISP WiFi Login Pages
-  min_ansible_version: 2.15
+  license: BSD
+  min_ansible_version: "2.15"
   issue_tracker_url: https://github.com/openwisp/openwisp-wifi-login-pages/issues
   platforms:
     - name: Debian
@@ -21,4 +22,4 @@ galaxy_info:
   galaxy_tags:
     - openwisp
     - wifi
-    - captive_portal
+    - captiveportal

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,10 +16,10 @@ scenario:
     - verify
     - cleanup
     - destroy
-  lint: |
-    set -e
-    yamllint .
-    ansible-lint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
 platforms:
   - name: "${ROLE_NAME:-instance}-${MOLECULE_DISTRO}"
     image: "geerlingguy/docker-${MOLECULE_DISTRO}-ansible:${tag:-latest}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,4 @@
 ---
-
 dependency:
   name: galaxy
 driver:
@@ -17,10 +16,10 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint . || true
-  ansible-lint || true
+  lint: |
+    set -e
+    yamllint .
+    ansible-lint
 platforms:
   - name: "${ROLE_NAME:-instance}-${MOLECULE_DISTRO}"
     image: "geerlingguy/docker-${MOLECULE_DISTRO}-ansible:${tag:-latest}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,10 +16,6 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
 platforms:
   - name: "${ROLE_NAME:-instance}-${MOLECULE_DISTRO}"
     image: "geerlingguy/docker-${MOLECULE_DISTRO}-ansible:${tag:-latest}"

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -1,5 +1,4 @@
 ---
-
 dependency:
   name: galaxy
 driver:
@@ -20,8 +19,8 @@ scenario:
     - destroy
 lint: |
   set -e
-  yamllint . || true
-  ansible-lint || true
+  yamllint .
+  ansible-lint
 platforms:
   - name: "openwisp2-ubuntu2404"
     image: "geerlingguy/docker-ubuntu2404-ansible:latest"

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -6,7 +6,6 @@ driver:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - cleanup
     - destroy
     - syntax
@@ -17,10 +16,6 @@ scenario:
     - verify
     - cleanup
     - destroy
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
 platforms:
   - name: "openwisp2-ubuntu2404"
     image: "geerlingguy/docker-ubuntu2404-ansible:latest"

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -5,8 +5,7 @@
 
   vars:
     wifi_login_pages_domains: ["localhost"]
-
   tasks:
     - name: "Include ansible role"
-      include_role:
+      ansible.builtin.include_role:
         name: "openwisp.wifi_login_pages"

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -6,46 +6,46 @@
 
   tasks:
     - name: Checking file is uploaded
-      stat:
+      ansible.builtin.stat:
         path: "/opt/openwisp2/wifi-login-pages/organizations/default/testfile"
       register: config_file
 
     - name: File exists
-      debug:
+      ansible.builtin.debug:
         msg: "The file is uploaded"
       when: config_file.stat.exists
 
     - name: File do not exists
-      fail:
+      ansible.builtin.fail:
         msg: "The file is not uploaded."
       when: not config_file.stat.exists
 
     - name: Checking translation is copied
-      stat:
+      ansible.builtin.stat:
         path: "/opt/openwisp2/wifi-login-pages/i18n/en.custom.po"
       register: translation_file
 
     - name: Translation file exists
-      debug:
+      ansible.builtin.debug:
         msg: "The file is uploaded"
       when: translation_file.stat.exists
 
     - name: Translation file do not exists
-      fail:
+      ansible.builtin.fail:
         msg: "The file is not uploaded."
       when: not translation_file.stat.exists
 
     - name: Checking static file is copied
-      stat:
+      ansible.builtin.stat:
         path: "/opt/openwisp2/wifi-login-pages/static/test_static_file"
       register: static_file
 
     - name: Static file exists
-      debug:
+      ansible.builtin.debug:
         msg: "The file is uploaded"
       when: static_file.stat.exists
 
     - name: Static file do not exists
-      fail:
+      ansible.builtin.fail:
         msg: "The file is not uploaded."
       when: not static_file.stat.exists

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -1,9 +1,15 @@
+echo 'Running checks for ansible-openwisp-wifi-login-pages'
+
 openwisp-qa-check \
 --skip-isort \
 --skip-flake8 \
 --skip-checkmigrations \
 --skip-black \
 
+echo 'Running yamllint'
+
 yamllint .
+
+echo 'Running ansible-lint'
 
 ansible-lint

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -1,5 +1,5 @@
 openwisp-qa-check \
 --skip-isort \
---skip-flake8 z
+--skip-flake8 \
 --skip-checkmigrations \
 --skip-black \

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -3,3 +3,7 @@ openwisp-qa-check \
 --skip-flake8 \
 --skip-checkmigrations \
 --skip-black \
+
+yamllint .
+
+ansible-lint

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -1,0 +1,5 @@
+openwisp-qa-check \
+--skip-isort \
+--skip-flake8 z
+--skip-checkmigrations \
+--skip-black \

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -1,15 +1,12 @@
-echo 'Running checks for ansible-openwisp-wifi-login-pages'
+#!/bin/bash
 
-openwisp-qa-check \
---skip-isort \
---skip-flake8 \
---skip-checkmigrations \
---skip-black \
-
-echo 'Running yamllint'
+set -e
 
 yamllint .
-
-echo 'Running ansible-lint'
-
 ansible-lint
+
+openwisp-qa-check \
+  --skip-isort \
+  --skip-flake8 \
+  --skip-checkmigrations \
+  --skip-black

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,6 +1,6 @@
 ---
 - name: Update APT package cache
-  apt:
+  ansible.builtin.apt:
     update_cache: true
   changed_when: false
   retries: 5
@@ -9,7 +9,7 @@
   until: result is success
 
 - name: Install system packages
-  apt:
+  ansible.builtin.apt:
     name:
       - gpg-agent
       - git
@@ -25,10 +25,11 @@
 - name: NodeJS deb source
   block:
     - name: Download nodesource gpg key
-      get_url:
+      ansible.builtin.get_url:
         url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
         dest: /etc/apt/trusted.gpg.d/nodesource.asc
         checksum: sha256:b42e0321dabdc24e892115da705cf061167eac12a317f23d329862d0aa0a271d
+        mode: "0644"
       ignore_errors: true
       retries: 5
       delay: 10
@@ -36,7 +37,7 @@
       until: result is success
 
     - name: Add nodejs 20.x ppa for apt repo
-      apt_repository:
+      ansible.builtin.apt_repository:
         repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/nodesource.asc] https://deb.nodesource.com/node_20.x nodistro main"
 
 - name: Yarn deb source
@@ -46,6 +47,7 @@
         url: https://dl.yarnpkg.com/debian/pubkey.gpg
         dest: /etc/apt/trusted.gpg.d/yarnpkg.asc
         checksum: sha256:f8f78154312934e7894e29da119c9fb06b489d36e0b36ec1538a5b8486a2f59e
+        mode: "0644"
       ignore_errors: true
       retries: 5
       delay: 10
@@ -53,11 +55,11 @@
       until: result is success
 
     - name: Add nodejs 20.x ppa for apt repo
-      apt_repository:
+      ansible.builtin.apt_repository:
         repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/yarnpkg.asc] https://dl.yarnpkg.com/debian/ stable main"
 
 - name: Install nodejs and yarn
-  apt:
+  ansible.builtin.apt:
     cache_valid_time: 3000
     name:
       - nodejs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,16 @@
 ---
-- import_tasks: apt.yml
+- name: Apt tasks
+  ansible.builtin.import_tasks: apt.yml
   tags: [wifi-login-pages, apt]
 
-- import_tasks: yarn.yml
+- name: Yarn tasks
+  ansible.builtin.import_tasks: yarn.yml
   tags: [wifi-login-pages, yarn]
 
-- import_tasks: supervisor.yml
+- name: Supervisor tasks
+  ansible.builtin.import_tasks: supervisor.yml
   tags: [wifi-login-pages, supervisor]
 
-- import_tasks: nginx.yml
+- name: Nginx tasks
+  ansible.builtin.import_tasks: nginx.yml
   tags: [wifi-login-pages, nginx]

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -1,65 +1,72 @@
 ---
-- name: create static directory
-  file:
+- name: Create static directory
+  ansible.builtin.file:
     dest: "{{ wifi_login_pages_path }}/static"
     group: "{{ www_group }}"
     owner: "{{ www_user }}"
     state: directory
+    mode: "0755"
 
-- name: create "{{ openwisp2_path }}/ssl"
-  file:
+- name: Create ssl directory
+  ansible.builtin.file:
     path: "{{ openwisp2_path }}/ssl"
     state: directory
-    mode: 0770
+    mode: "0770"
 
-- name: create "{{ openwisp2_path }}/nginx-conf/wifi-login-pages"
-  file:
+- name: Create nginx-conf directory
+  ansible.builtin.file:
     path: "{{ openwisp2_path }}/nginx-conf/wifi-login-pages"
     state: directory
-    mode: 0770
+    mode: "0770"
 
-- name: create SSL cert if not exists yet
-  command: >
-    openssl req -new -nodes -x509 \
-    -subj "/C={{ openwisp2_ssl_country }}/ST={{ openwisp2_ssl_state }} \
-           /L={{ openwisp2_ssl_locality }}/O={{ openwisp2_ssl_organization }} \
-           /CN={{ openwisp2_ssl_common_name }}" \
-    -days 3650 \
-    -keyout {{ wifi_login_pages_ssl_key }} \
-    -out {{ wifi_login_pages_ssl_cert }} \
-    -extensions v3_ca creates={{ wifi_login_pages_ssl_cert }}
-  notify: restart nginx
+- name: Create SSL cert if not exists yet
+  vars:
+    ssl_subj: >-
+      /C={{ openwisp2_ssl_country }}/ST={{
+      openwisp2_ssl_state }}/L={{ openwisp2_ssl_locality
+      }}/O={{ openwisp2_ssl_organization }}/CN={{
+      openwisp2_ssl_common_name }}
+  ansible.builtin.command: >-
+    openssl req -new -nodes -x509
+    -subj "{{ ssl_subj }}"
+    -days 3650
+    -keyout {{ wifi_login_pages_ssl_key }}
+    -out {{ wifi_login_pages_ssl_cert }}
+    -extensions v3_ca
+  args:
+    creates: "{{ wifi_login_pages_ssl_cert }}"
+  notify: Restart nginx
 
-- name: nginx SSL configuration
-  template:
+- name: Nginx SSL configuration
+  ansible.builtin.template:
     src: nginx/ssl-conf.j2
     dest: "{{ openwisp2_path }}/nginx-conf/wifi-login-pages/ssl.conf"
-    mode: 0644
-  notify: restart nginx
+    mode: "0644"
+  notify: Restart nginx
 
-- name: nginx security configuration
-  template:
+- name: Nginx security configuration
+  ansible.builtin.template:
     src: nginx/security-conf.j2
     dest: "{{ openwisp2_path }}/nginx-conf/wifi-login-pages/security.conf"
-    mode: 0644
-  notify: restart nginx
+    mode: "0644"
+  notify: Restart nginx
 
-- name: nginx site available
-  template:
+- name: Nginx site available
+  ansible.builtin.template:
     src: nginx/site-conf.j2
     dest: "/etc/nginx/sites-available/wifi_login_pages"
-    mode: 0644
-  notify: restart nginx
+    mode: "0644"
+  notify: Restart nginx
 
-- name: enable nginx site
-  file:
+- name: Enable nginx site
+  ansible.builtin.file:
     src: "/etc/nginx/sites-available/wifi_login_pages"
     dest: "/etc/nginx/sites-enabled/wifi_login_pages"
     state: link
-  notify: restart nginx
+  notify: Restart nginx
 
 - name: Configure nginx log rotation
-  template:
+  ansible.builtin.template:
     src: logrotate.d/owlp-nginx.j2
     dest: "/etc/logrotate.d/owlp-nginx"
-    mode: 0644
+    mode: "0644"

--- a/tasks/supervisor.yml
+++ b/tasks/supervisor.yml
@@ -1,6 +1,7 @@
 ---
-- name: supervisor configuration
-  template:
+- name: Supervisor configuration
+  ansible.builtin.template:
     src: supervisor.j2
     dest: "{{ supervisor_path | format('wifi_login_pages') }}"
-  notify: reload supervisor
+    mode: "0644"
+  notify: Reload supervisor

--- a/tasks/yarn.yml
+++ b/tasks/yarn.yml
@@ -1,39 +1,42 @@
 ---
-- name: openwisp-wifi-login-pages.git
-  git:
-    repo: "{{ wifi_login_pages_repo_url}}"
+- name: Openwisp-wifi-login-pages.git
+  ansible.builtin.git:
+    repo: "{{ wifi_login_pages_repo_url }}"
     dest: "{{ wifi_login_pages_path }}"
     version: "{{ wifi_login_pages_version }}"
     force: true
   tags: git
 
-- name: yarn install
+- name: Yarn install
   community.general.yarn:
     path: "{{ wifi_login_pages_path }}"
 
-- name: create log directory
-  file:
+- name: Create log directory
+  ansible.builtin.file:
     dest: "{{ wifi_login_pages_path }}/log"
     group: "{{ www_group }}"
     owner: "{{ www_user }}"
     state: directory
+    mode: "0750"
 
-- name: create yarn cache directory
-  file:
+- name: Create yarn cache directory
+  ansible.builtin.file:
     dest: "/var/www/.cache/yarn"
     group: "{{ www_group }}"
     owner: "{{ www_user }}"
     state: directory
+    mode: "0750"
 
-- name: create npm directory
-  file:
+- name: Create npm directory
+  ansible.builtin.file:
     dest: "/var/www/.npm"
     group: "{{ www_group }}"
     owner: "{{ www_user }}"
     state: directory
+    mode: "0750"
 
-- name: set permissions
-  file:
+- name: Set permissions
+  ansible.builtin.file:
     dest: "{{ wifi_login_pages_path }}"
     group: "{{ www_group }}"
     owner: "{{ www_user }}"
@@ -41,43 +44,44 @@
     mode: u=rwX,g=rX,o=X
     recurse: true
 
-- name: copy organizations configs and assets
+- name: Copy organizations configs and assets
   become: true
-  copy:
+  ansible.builtin.copy:
     src: "{{ wifi_login_pages_organizations_src }}"
     dest: "{{ wifi_login_pages_path }}/organizations"
     owner: "{{ www_user }}"
     group: "{{ www_group }}"
-    mode: 0640
+    mode: "0640"
   failed_when: false
   tags: [assets]
 
-- name: copy translations (i18n directory)
+- name: Copy translations (i18n directory)
   become: true
-  copy:
+  ansible.builtin.copy:
     src: owlp_i18n/
     dest: "{{ wifi_login_pages_path }}/i18n"
     owner: "{{ www_user }}"
     group: "{{ www_group }}"
-    mode: 0640
+    mode: "0640"
   failed_when: false
   tags: [i18n]
 
-- name: copy static files
+- name: Copy static files
   become: true
-  copy:
+  ansible.builtin.copy:
     src: owlp_static/
     dest: "{{ wifi_login_pages_path }}/static"
     owner: "{{ www_user }}"
     group: "{{ www_group }}"
-    mode: 0640
+    mode: "0640"
   failed_when: false
   tags: [assets]
 
-- name: yarn build
+- name: Yarn build
   become: true
   become_user: "{{ www_user }}"
-  command: "yarn build"
+  ansible.builtin.command: "yarn build"
   args:
     chdir: "{{ wifi_login_pages_path }}"
+  changed_when: true
   tags: [yarn-build]


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #42.

## Description of Changes

Added the 'run-qa-checks' file to the root directory and moved the QA checks command from '.github/workflows/ci.yml' and changed to call the 'run-qa-checks' file from the root. Additionally, removed the '| true' flag from the lint command in 'molecule/default/molecule.yml' and 'molecule/local/molecule.yml', respectively, to prevent lint errors from silently being ignored.

## Screenshot

Please include any relevant screenshots.
