### PR TITLE
[ci] Enabled issue autoassignment bots

### DIFF
--- a/.github/workflows/bot-autoassign-issue.yml
+++ b/.github/workflows/bot-autoassign-issue.yml
@@ -1,0 +1,19 @@
+name: Issue Assignment Bot
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: read
+  issues: write
+concurrency:
+  group: bot-autoassign-issue-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+jobs:
+  respond-to-assign-request:
+    if: github.event.issue.pull_request == null
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: issue_assignment
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-issue.yml
+++ b/.github/workflows/bot-autoassign-issue.yml
@@ -1,3 +1,4 @@
+---
 name: Issue Assignment Bot
 on:
   issue_comment:

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -1,0 +1,20 @@
+name: PR Issue Auto-Assignment
+on:
+  pull_request_target:
+    types: [opened, reopened, closed]
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+concurrency:
+  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  cancel-in-progress: true
+jobs:
+  auto-assign-issue:
+    if: github.event.action != 'closed' || github.event.pull_request.merged == false
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: issue_assignment
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -1,3 +1,4 @@
+---
 name: PR Issue Auto-Assignment
 on:
   pull_request_target:

--- a/.github/workflows/bot-autoassign-pr-reopen.yml
+++ b/.github/workflows/bot-autoassign-pr-reopen.yml
@@ -1,0 +1,30 @@
+name: PR Reopen Reassignment
+on:
+  pull_request_target:
+    types: [reopened]
+  issue_comment:
+    types: [created]
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+concurrency:
+  group: bot-autoassign-pr-reopen-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+jobs:
+  reassign-on-reopen:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'reopened'
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: pr_reopen
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
+  handle-pr-activity:
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: pr_reopen
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-pr-reopen.yml
+++ b/.github/workflows/bot-autoassign-pr-reopen.yml
@@ -1,3 +1,4 @@
+---
 name: PR Reopen Reassignment
 on:
   pull_request_target:

--- a/.github/workflows/bot-autoassign-stale-pr.yml
+++ b/.github/workflows/bot-autoassign-stale-pr.yml
@@ -1,0 +1,20 @@
+name: Stale PR Management
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+concurrency:
+  group: bot-autoassign-stale-pr-${{ github.repository }}
+  cancel-in-progress: false
+jobs:
+  manage-stale-prs-python:
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: stale_pr
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-stale-pr.yml
+++ b/.github/workflows/bot-autoassign-stale-pr.yml
@@ -1,3 +1,4 @@
+---
 name: Stale PR Management
 on:
   schedule:


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

This PR adds the GitHub Actions workflows to auto-assign issues, manage PR-issue linking, handle PR reopening reassignment, and manage stale PRs.
These workflows check out `openwisp/openwisp-utils` to run the bot Python scripts, ensuring uniform behavior across all repositories.
Related to the auto-assignment issue bot implementation.